### PR TITLE
Implement html decoding in titles of events

### DIFF
--- a/src/components/events/events.component.tsx
+++ b/src/components/events/events.component.tsx
@@ -22,9 +22,11 @@ const EventsComponent = () => {
     }, []);
 
     const renderEvent = (e: EventType) => {
+	// Decode HTML special characters (such as ' or &)
         const htmlDecode = ((content: string) => {
-            let e = document.createElement('div');
+            let e = document.createElement('textarea');
             e.innerHTML = content;
+	    e.innerHTML = e.value;
             return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
         })
 
@@ -32,7 +34,7 @@ const EventsComponent = () => {
         // Preparing to use Markdown instead of HTML
         return (
             <div key={e.EventID + e.EventDetailsID}>
-                <h3>{e.Title}</h3>
+                <h3>{htmlDecode(e.Title)}</h3>
                 <p>{e.DatetimeFormatted}</p>
 
                 <br></br>


### PR DESCRIPTION
Currently events with special characters (like the ' in Hack 'n' Craic) are rendered incorrectly:
![image](https://github.com/user-attachments/assets/e5877ce3-3ed7-4c58-92b1-962d7b9aada3)

This fix implements a slightly modified version of the already existing htmlDecode function to resolve this. Running the website locally with this change looks like this:
![image](https://github.com/user-attachments/assets/dbe0e7ab-db0d-4e98-b14f-e4bd8787be05)
