### PR TITLE
Fix GitHub Pages route 404s

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,13 @@ jobs:
       
       - name: Build
         run: npm run build
+
+      - name: Create route entrypoints
+        run: |
+          for route in ctf committee constitution; do
+            mkdir -p "build/$route"
+            cp build/index.html "build/$route/index.html"
+          done
       
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/public/index.html
+++ b/public/index.html
@@ -30,20 +30,20 @@
                   content="/assets/img/compsoc-meta-social-banner.png">
 
             <!-- Favicons -->
-            <link rel="icon" href="assets/img/favicon.png" />
-            <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+            <link rel="icon" href="/assets/img/favicon.png" />
+            <link href="/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
 
             <!-- Google Fonts -->
             <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,500,500i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i"
                   rel="stylesheet">
 
-            <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-            <link href="assets/vendor/icofont/icofont.min.css" rel="stylesheet">
-            <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-            <link href="assets/vendor/venobox/venobox.css" rel="stylesheet">
-            <link href="assets/vendor/owl.carousel/assets/owl.carousel.min.css" rel="stylesheet">
-            <link href="assets/vendor/aos/aos.css" rel="stylesheet">
-            <link href="assets/css/style.css" rel="stylesheet">
+            <link href="/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+            <link href="/assets/vendor/icofont/icofont.min.css" rel="stylesheet">
+            <link href="/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+            <link href="/assets/vendor/venobox/venobox.css" rel="stylesheet">
+            <link href="/assets/vendor/owl.carousel/assets/owl.carousel.min.css" rel="stylesheet">
+            <link href="/assets/vendor/aos/aos.css" rel="stylesheet">
+            <link href="/assets/css/style.css" rel="stylesheet">
 
             <script>
                   var nobodywilleverseethis = ["Why are you in the console?", "I'm just here for the pints","Please help me. I'm stuck inside Mojo and can't get out!","Why did the programmer quit his job? Because he didnt get arrays...", "An SEO expert walks into a bar, bars, pub, tavern, public house, irish pub, drinks, beer...",
@@ -64,16 +64,16 @@
             <div id="root"></div>
 
             <!-- Vendor JS Files -->
-            <script src="assets/vendor/jquery/jquery.min.js"></script>
-            <script src="assets/vendor/jquery/jquery.counterup.min.js"></script>
-            <script src="assets/vendor/jquery/jquery.waypoints.min.js"></script>
-            <script src="assets/vendor/venobox/venobox.min.js" rel="stylesheet"></script>
-            <script src="assets/vendor/owl.carousel/owl.carousel.min.js" rel="stylesheet"></script>
-            <script src="assets/vendor/aos/aos.js"></script>
-            <script src="assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-            <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
+            <script src="/assets/vendor/jquery/jquery.min.js"></script>
+            <script src="/assets/vendor/jquery/jquery.counterup.min.js"></script>
+            <script src="/assets/vendor/jquery/jquery.waypoints.min.js"></script>
+            <script src="/assets/vendor/venobox/venobox.min.js" rel="stylesheet"></script>
+            <script src="/assets/vendor/owl.carousel/owl.carousel.min.js" rel="stylesheet"></script>
+            <script src="/assets/vendor/aos/aos.js"></script>
+            <script src="/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+            <script src="/assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
 
             <!-- Template Main JS File -->
-            <script src="assets/js/main.js"></script>
+            <script src="/assets/js/main.js"></script>
       </body>
 </html>

--- a/src/components/about/about.component.tsx
+++ b/src/components/about/about.component.tsx
@@ -5,7 +5,7 @@ const AboutComponent = () => {
                 <div className="container">
                     <img
                         alt=""
-                        src="assets/img/compsoc_banner_blue_black.png"
+                        src="/assets/img/compsoc_banner_blue_black.png"
                         width="30%"
                     ></img>
                     <br></br>

--- a/src/components/footer/footer.component.tsx
+++ b/src/components/footer/footer.component.tsx
@@ -5,7 +5,7 @@ const FooterComponent = () => {
         <div className="copyright">
           <a href="https://universityofgalway.ie/">
             <img
-              src="assets/img/universityofgalway.jpg"
+              src="/assets/img/universityofgalway.jpg"
               alt="University of Galway"
             ></img>
           </a>


### PR DESCRIPTION
Fixed 404s from the GitHub Pages migration by generating entrypoints for each route and using root-relative asset paths.

Tested with the production build and direct route loads.